### PR TITLE
Handle unknown commands / generators

### DIFF
--- a/cmd/fakedata.go
+++ b/cmd/fakedata.go
@@ -25,6 +25,9 @@ var usage = `
     --version       shows version information
 `
 
+var unknownGeneratorError = `
+  Unknown generator: %s.`
+
 var generatorsFlag = flag.Bool("generators", false, "lists available generators")
 var limitFlag = flag.Int("limit", 10, "limits rows up to n")
 var helpFlag = flag.Bool("help", false, "shows help information")
@@ -65,6 +68,32 @@ func generatorsHelp(generators []fakedata.Generator) string {
 	return buffer.String()
 }
 
+// Validate generators passed as flags
+func validateGenerators(generators []fakedata.Generator) {
+	availableGens := make(map[string]bool)
+	// Assume generators exist
+	var hasGenerator = true
+
+	// Create a map from the generator slice
+	for _, v := range generators {
+		availableGens[v.Name] = true
+	}
+	// check each parameter
+	for f := range flag.Args() {
+		k := flag.Arg(f)
+		// If the parameter is not a generator, fail and log message.
+		if !availableGens[k] {
+			fmt.Printf(unknownGeneratorError, k)
+			hasGenerator = false
+		}
+	}
+	// If one generator does not exist, exit and print a message about --generators
+	if hasGenerator == false {
+		fmt.Println("\n\n  Please check fakedata --generators for more information about available generators.")
+		os.Exit(0)
+	}
+}
+
 func main() {
 	if *versionFlag {
 		fmt.Println(version)
@@ -85,6 +114,9 @@ func main() {
 		fmt.Printf(usage)
 		os.Exit(0)
 	}
+
+	// Validate generators exist
+	validateGenerators(fakedata.Generators())
 
 	rand.Seed(time.Now().UnixNano())
 

--- a/cmd/fakedata.go
+++ b/cmd/fakedata.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/lucapette/fakedata/pkg/fakedata"
@@ -81,6 +82,11 @@ func validateGenerators(generators []fakedata.Generator) {
 	// check each parameter
 	for f := range flag.Args() {
 		k := flag.Arg(f)
+		paramArg := strings.Split(k, ",")
+		// Seperate arguments that have parameters, e.g. int,1..50
+		if len(paramArg) > 1 {
+			k = paramArg[0]
+		}
 		// If the parameter is not a generator, fail and log message.
 		if !availableGens[k] {
 			fmt.Printf(unknownGeneratorError, k)

--- a/cmd/fakedata.go
+++ b/cmd/fakedata.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/kevingimbel/fakedata/pkg/fakedata"
+	"github.com/lucapette/fakedata/pkg/fakedata"
 	flag "github.com/spf13/pflag"
 )
 

--- a/pkg/fakedata/fakedata.go
+++ b/pkg/fakedata/fakedata.go
@@ -2,7 +2,12 @@ package fakedata
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 )
+
+var unknownGeneratorError = `
+  Unknown generator: %s.`
 
 // GenerateRow generates a row of fake data using Columns
 // in the specified format
@@ -19,4 +24,26 @@ func GenerateRow(columns Columns, formatter Formatter) string {
 	output.WriteString("\n")
 
 	return output.String()
+}
+
+// ValidateGenerators validates the passed generators agains available generators
+func ValidateGenerators(keys []string) error {
+	// check each parameter
+	var validationError []string
+	var err error
+	for _, k := range keys {
+		paramArg := strings.Split(k, ",")
+		// Seperate arguments that have parameters, e.g. int,1..50
+		if len(paramArg) > 1 {
+			k = paramArg[0]
+		}
+		if generators[k].Name != k {
+			validationError = append(validationError, fmt.Errorf(unknownGeneratorError, k).Error())
+		}
+	}
+	// If there are errors, join them into one big string
+	if len(validationError) > 0 {
+		err = fmt.Errorf(strings.Join(validationError, ""))
+	}
+	return err
 }

--- a/pkg/fakedata/fakedata_test.go
+++ b/pkg/fakedata/fakedata_test.go
@@ -179,3 +179,28 @@ func TestGenerateRowWithEnum(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateGenerators(t *testing.T) {
+	type args struct {
+		keys []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"known generator", args{keys: []string{"email", "domain"}}, false},
+		{"unknown generator", args{keys: []string{"nogen"}}, true},
+		{"mixed generators", args{keys: []string{"nogen", "email", "domain"}}, true},
+		{"generator with arguments", args{keys: []string{"int,1..100"}}, false},
+		{"mixed generator with arguments", args{keys: []string{"int,1..100", "domain", "email"}}, false},
+		{"mixed unknwon generator with arguments", args{keys: []string{"int,1..100", "salery,10k..100k", "email"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := fakedata.ValidateGenerators(tt.args.keys); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateKeys() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds a `validateGenerators` function to the main loop which
validates the passed generators and stops execution if a validator is
not found.

While starting my work on #9 I realized that it is possible that one or more generators / arguments can be wrong and therefore result in unexpected output. For example, running the following command will create a "wrong" output. 

```sh
$ fakedata email name.first name.lst state country --format csv
```

The parameter `name.lst` is spelled wrong but previously `fakedata` did not throw errors so it would simply create a file in the format `email, name.first, state, country`. With this commit and the new `validateGenerators` function it throws an error:

```sh
$ fakedata email name.first name.lst state country --format csv

  Unknown generator: name.lst.

  Please check fakedata --generators for more information about available generators.
```

I am not entirely happy with the implementation of `validateGenerators`. Because I did not find a way to get the generators map I am creating a temporary one inside `validateGenerators` to "easily" check if any of the supplied generators is not valid. I did some (poor) performance testing by running `fakedata` with and without `validateGenerators` but could not observe any impacts.

