### PR TITLE
Refactor generator validation

### DIFF
--- a/cmd/fakedata.go
+++ b/cmd/fakedata.go
@@ -68,14 +68,14 @@ func main() {
 		os.Exit(0)
 	}
 
-	if err := fakedata.ValidateGenerators(flag.Args()); err != nil {
+	rand.Seed(time.Now().UnixNano())
+
+	columns, err := fakedata.NewColumns(flag.Args())
+	if err != nil {
 		fmt.Printf("%v\n\nSee fakedata --generators for a list of available generators.\n", err)
 		os.Exit(0)
 	}
 
-	rand.Seed(time.Now().UnixNano())
-
-	columns := fakedata.NewColumns(flag.Args())
 	formatter := getFormatter(*formatFlag)
 
 	for i := 0; i < *limitFlag; i++ {

--- a/pkg/fakedata/column.go
+++ b/pkg/fakedata/column.go
@@ -1,6 +1,7 @@
 package fakedata
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 )
@@ -20,8 +21,9 @@ func (c *Column) String() string {
 type Columns []Column
 
 // NewColumns returns an array of Columns using keys as a specification
-func NewColumns(keys []string) (cols Columns) {
+func NewColumns(keys []string) (cols Columns, err error) {
 	cols = make(Columns, len(keys))
+	var errors bytes.Buffer
 
 	for i, k := range keys {
 		specs := strings.Split(k, ",")
@@ -41,11 +43,19 @@ func NewColumns(keys []string) (cols Columns) {
 			key = values[0]
 		}
 
+		if _, ok := generators[key]; !ok {
+			errors.WriteString(fmt.Sprintf("Unknown generator: %s.\n", key))
+		}
+
 		cols[i].Name = name
 		cols[i].Key = key
 	}
 
-	return cols
+	if errors.Len() > 0 {
+		err = fmt.Errorf(errors.String())
+	}
+
+	return cols, err
 }
 
 func (columns Columns) names() (names []string) {

--- a/pkg/fakedata/column_test.go
+++ b/pkg/fakedata/column_test.go
@@ -21,8 +21,16 @@ func TestNewColumns(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if actual, err := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) && ((err != nil) != tt.wantErr) {
+			actual, err := fakedata.NewColumns(tt.input)
+
+			// Test fails with unexpected result
+			if !reflect.DeepEqual(actual, tt.expected) && !tt.wantErr {
 				t.Errorf("NewColumns() = %v, want %v", actual, tt.expected)
+			}
+
+			// Dont't want error but got error
+			if (err != nil) && !tt.wantErr {
+				t.Errorf("NewColumns() = Dont want error but got: %v", err)
 			}
 		})
 	}
@@ -40,8 +48,15 @@ func TestNewColumnsWithName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if actual, err := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) && ((err != nil) != tt.wantErr) {
+			actual, err := fakedata.NewColumns(tt.input)
+			// Test fails with unexpected result
+			if !reflect.DeepEqual(actual, tt.expected) && !tt.wantErr {
 				t.Errorf("NewColumns() = %v, want %v", actual, tt.expected)
+			}
+
+			// Dont't want error but got error
+			if (err != nil) && !tt.wantErr {
+				t.Errorf("NewColumns() = Dont want error but got: %v", err)
 			}
 		})
 	}
@@ -56,13 +71,19 @@ func TestNewColumnsWithSpec(t *testing.T) {
 	}{
 		{name: "int full range", input: []string{"int,1..100"}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "1..100"}}, wantErr: false},
 		{name: "int lower bound", input: []string{"int,1.."}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "1.."}}, wantErr: false},
-		{name: "int lower bound no range syntax", input: []string{"int,10"}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "10"}}, wantErr: false},
-		{name: "int spelled wrong", input: []string{"integer,10"}, expected: nil, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if actual, err := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) && ((err != nil) != tt.wantErr) {
-				t.Errorf("NewColumns() = %v, expected %v", actual, tt.expected)
+			actual, err := fakedata.NewColumns(tt.input)
+
+			// Test fails with unexpected result
+			if !reflect.DeepEqual(actual, tt.expected) && !tt.wantErr {
+				t.Errorf("NewColumns() = %v, want %v", actual, tt.expected)
+			}
+
+			// Dont't want error but got error
+			if (err != nil) && !tt.wantErr {
+				t.Errorf("NewColumns() = Dont want error but got: %v", err)
 			}
 		})
 	}

--- a/pkg/fakedata/column_test.go
+++ b/pkg/fakedata/column_test.go
@@ -12,13 +12,16 @@ func TestNewColumns(t *testing.T) {
 		name     string
 		input    []string
 		expected fakedata.Columns
+		wantErr  bool
 	}{
-		{name: "one column", input: []string{"email"}, expected: fakedata.Columns{{Key: "email", Name: "email"}}},
-		{name: "two columns", input: []string{"email", "domain"}, expected: fakedata.Columns{{Key: "email", Name: "email"}, {Key: "domain", Name: "domain"}}},
+		{name: "one column", input: []string{"email"}, expected: fakedata.Columns{{Key: "email", Name: "email"}}, wantErr: false},
+		{name: "two columns", input: []string{"email", "domain"}, expected: fakedata.Columns{{Key: "email", Name: "email"}, {Key: "domain", Name: "domain"}}, wantErr: false},
+		{name: "two columns, one column fails", input: []string{"email", "domain", "unsupportedgenerator"}, expected: nil, wantErr: true},
+		{name: "one column, all fails", input: []string{"madeupgenerator"}, expected: nil, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if actual := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) {
+			if actual, err := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) && ((err != nil) != tt.wantErr) {
 				t.Errorf("NewColumns() = %v, want %v", actual, tt.expected)
 			}
 		})
@@ -30,12 +33,14 @@ func TestNewColumnsWithName(t *testing.T) {
 		name     string
 		input    []string
 		expected fakedata.Columns
+		wantErr  bool
 	}{
-		{name: "one column", input: []string{"login=email"}, expected: fakedata.Columns{{Key: "email", Name: "login"}}},
+		{name: "one column", input: []string{"login=email"}, expected: fakedata.Columns{{Key: "email", Name: "login"}}, wantErr: false},
+		{name: "one column, unupported generator", input: []string{"login=notagen"}, expected: nil, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if actual := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) {
+			if actual, err := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) && ((err != nil) != tt.wantErr) {
 				t.Errorf("NewColumns() = %v, want %v", actual, tt.expected)
 			}
 		})
@@ -47,14 +52,16 @@ func TestNewColumnsWithSpec(t *testing.T) {
 		name     string
 		input    []string
 		expected fakedata.Columns
+		wantErr  bool
 	}{
-		{name: "int full range", input: []string{"int,1..100"}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "1..100"}}},
-		{name: "int lower bound", input: []string{"int,1.."}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "1.."}}},
-		{name: "int lower bound no range syntax", input: []string{"int,10"}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "10"}}},
+		{name: "int full range", input: []string{"int,1..100"}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "1..100"}}, wantErr: false},
+		{name: "int lower bound", input: []string{"int,1.."}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "1.."}}, wantErr: false},
+		{name: "int lower bound no range syntax", input: []string{"int,10"}, expected: fakedata.Columns{{Key: "int", Name: "int", Constraints: "10"}}, wantErr: false},
+		{name: "int spelled wrong", input: []string{"integer,10"}, expected: nil, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if actual := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) {
+			if actual, err := fakedata.NewColumns(tt.input); !reflect.DeepEqual(actual, tt.expected) && ((err != nil) != tt.wantErr) {
 				t.Errorf("NewColumns() = %v, expected %v", actual, tt.expected)
 			}
 		})

--- a/pkg/fakedata/fakedata.go
+++ b/pkg/fakedata/fakedata.go
@@ -1,10 +1,6 @@
 package fakedata
 
-import (
-	"bytes"
-	"fmt"
-	"strings"
-)
+import "bytes"
 
 // GenerateRow generates a row of fake data using columns
 // in the specified format
@@ -21,22 +17,4 @@ func GenerateRow(columns Columns, formatter Formatter) string {
 	output.WriteString("\n")
 
 	return output.String()
-}
-
-// ValidateGenerators validates each key in keys against available generators
-func ValidateGenerators(keys []string) (err error) {
-	var errors bytes.Buffer
-
-	for _, k := range keys {
-		key := strings.Split(k, ",")[0]
-
-		if _, ok := generators[key]; !ok {
-			errors.WriteString(fmt.Sprintf("Unknown generator: %s.\n", key))
-		}
-	}
-
-	if errors.Len() > 0 {
-		err = fmt.Errorf(errors.String())
-	}
-	return err
 }

--- a/pkg/fakedata/fakedata_test.go
+++ b/pkg/fakedata/fakedata_test.go
@@ -179,28 +179,3 @@ func TestGenerateRowWithEnum(t *testing.T) {
 		})
 	}
 }
-
-func TestValidateGenerators(t *testing.T) {
-	type args struct {
-		keys []string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{"known generator", args{keys: []string{"email", "domain"}}, false},
-		{"unknown generator", args{keys: []string{"nogen"}}, true},
-		{"mixed generators", args{keys: []string{"nogen", "email", "domain"}}, true},
-		{"generator with arguments", args{keys: []string{"int,1..100"}}, false},
-		{"mixed generators with arguments", args{keys: []string{"int,1..100", "domain", "email"}}, false},
-		{"mixed unknown generators with arguments", args{keys: []string{"int,1..100", "salary,10k..100k", "email"}}, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := fakedata.ValidateGenerators(tt.args.keys); (err != nil) != tt.wantErr {
-				t.Errorf("ValidateKeys() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}


### PR DESCRIPTION
This patch reverts the changes made in #10 and places the generator
validation inside the `NewColumns` function. 
Tests have been adjusted so that they can handle expected error cases for unknown generators.

I manually tested it and ran the tests locally with `make test` and I believe this time nothing is broken! 😄 