### PR TITLE
Two new generators: namereverse, concated

### DIFF
--- a/integration/generators.golden
+++ b/integration/generators.golden
@@ -1,4 +1,5 @@
 color             one word color
+concated          concatenate two fields with separator Defaults to "latitude..longitude..,"
 country           Full country name
 country.code      2-digit country code
 date              YYYY-MM-DD. Accepts a range in the format YYYY-MM-DD..YYYY-MM-DD. By default, it generates dates in the last year.
@@ -19,6 +20,7 @@ mac.address       mac address
 name              name.first + " " + name.last
 name.first        capitalized first name
 name.last         capitalized last name
+namereverse       reverse name order
 product.category  Beauty|Games|Movies|Tools|..
 product.name      invented product name
 state             Full US state name

--- a/pkg/fakedata/generator.go
+++ b/pkg/fakedata/generator.go
@@ -175,6 +175,17 @@ var enum = func(column Column) string {
 	return withEnum(enum)(column)
 }
 
+var concated = func(column Column) string {
+	concated := []string{"latitude", "longitude", ","}
+
+	if len(column.Constraints) > 1 {
+		concated = strings.Split(column.Constraints, "..")
+	}
+
+    return withSep(Column{Key: concated[0]}, Column{Key: concated[1]}, concated[2])(column)
+}
+
+
 func init() {
 	generators = make(map[string]Generator)
 
@@ -280,6 +291,12 @@ func init() {
 		Func: withSep(Column{Key: "name.first"}, Column{Key: "name.last"}, " "),
 	}
 
+	generators["namereverse"] = Generator{
+		Name: "namereverse",
+		Desc: `reverse name order`,
+		Func: withSep(Column{Key: "name.last"}, Column{Key: "name.first"}, " "),
+	}
+
 	generators["email"] = Generator{
 		Name: "email",
 		Desc: "email",
@@ -330,4 +347,11 @@ func init() {
 		Desc: `a random value from an enum. Defaults to "foo..bar..baz"`,
 		Func: enum,
 	}
+
+	generators["concated"] = Generator{
+		Name: "concated",
+		Desc: `concatenate two fields with separator Defaults to "latitude..longitude..,"`,
+		Func: concated,
+	}
+
 }

--- a/pkg/fakedata/generator.go
+++ b/pkg/fakedata/generator.go
@@ -182,7 +182,7 @@ var concated = func(column Column) string {
 		concated = strings.Split(column.Constraints, "..")
 	}
 
-    return withSep(Column{Key: concated[0]}, Column{Key: concated[1]}, concated[2])(column)
+	return withSep(Column{Key: concated[0]}, Column{Key: concated[1]}, concated[2])(column)
 }
 
 


### PR DESCRIPTION
**namereverse** is simple reversing of the **name** generator
**concated** is a clone of **enum** generator, but with using the first 3 items as first field, second field, separator between supplied as parameters to **withSep** function.

**TODO:**

- checking for all 3 parameters, if a variable to concated generator is supplied by the user
- only allow simple generators, to avoid index issues by too much '..' in the variable to concated


I am lot less experienced in programming than @kevingimbel, also to be specific, this is my first hacking in Go, so please be patient with me, and my changes :)