### PR TITLE
Fix spelling mistake in int description

### DIFF
--- a/integration/generators.golden
+++ b/integration/generators.golden
@@ -10,7 +10,7 @@ email             email
 enum              a random value from an enum. Defaults to "foo..bar..baz"
 event.action      clicked|purchased|viewed|watched
 http.method       DELETE|GET|HEAD|OPTION|PATCH|POST|PUT
-int               positive integer. Accepts range mix..max (default: 1..1000).
+int               positive integer. Accepts range min..max (default: 1..1000).
 ipv4              ipv4
 ipv6              ipv6
 latitude          latitude

--- a/pkg/fakedata/generator.go
+++ b/pkg/fakedata/generator.go
@@ -321,7 +321,7 @@ func init() {
 
 	generators["int"] = Generator{
 		Name: "int",
-		Desc: "positive integer. Accepts range mix..max (default: 1..1000).",
+		Desc: "positive integer. Accepts range min..max (default: 1..1000).",
 		Func: integer,
 	}
 


### PR DESCRIPTION
I noticed there was a spelling mistake in the description of `int`. It said `Accepts range mix..max` where it should be `Accepts range min..max`. 

Should (or can) I merge small-ish corrections like these myself or should I do pull requests for them, too? 