### PR TITLE
WIP: bash/zsh completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Generators](#generators)
   - [Constraints](#constraints)
 - [Templates](#templates)
+- [Completion](#completion)
 - [How to install](#how-to-install)
 - [How to contribute](#how-to-contribute)
 - [Code of conduct](#code-of-conduct)
@@ -326,6 +327,24 @@ example to display a full name in the format `Lastname Firstname` instead of
 ```html
 {{ printf "%s %s" NameLast NameFirst }}
 ```
+
+# Completion
+
+`fakedata` supports shell tab completion for bash and zsh shells. To enable completion execute one of the following commands
+ to append the completion function to your `.bashrc` or `.zshrc` file.
+
+```sh
+$ fakedata --completion bash >> $HOME/.bashrc
+$ fakedata --completion zsh >> $HOME/.zshrc
+```
+
+Alternatively for bash you can also add a file to `/etc/bash_completion.d/` named `fakedata` like so.
+
+```sh
+$ fakedata --completion bash >> /etc/bash_completion.d/fakedata
+```
+
+As of now you'll need to update the `/etc/bash_completion.d/fakedata` file or the function inside `.bashrc` / `.zshrc` when you update fakedata.
 
 # How to install
 

--- a/integration/golden/file-does-not-exist.golden
+++ b/integration/golden/file-does-not-exist.golden
@@ -2,6 +2,7 @@ could not read file this file does not exist.txt: open this file does not exist.
 
 Usage: fakedata [option ...] field...
 
+  -C, --completion string             print bash/zsh completion function, pass shell as argument ("bash" or "zsh")
   -f, --format string                 generators rows in f format. Available formats: csv|tab|sql
   -g, --generator string              show help for a specific generator
   -G, --generators                    lists available generators

--- a/integration/golden/help.golden
+++ b/integration/golden/help.golden
@@ -1,5 +1,6 @@
 Usage: fakedata [option ...] field...
 
+  -C, --completion string             print bash/zsh completion function, pass shell as argument ("bash" or "zsh")
   -f, --format string                 generators rows in f format. Available formats: csv|tab|sql
   -g, --generator string              show help for a specific generator
   -G, --generators                    lists available generators

--- a/integration/golden/path-empty.golden
+++ b/integration/golden/path-empty.golden
@@ -2,6 +2,7 @@ no file path given
 
 Usage: fakedata [option ...] field...
 
+  -C, --completion string             print bash/zsh completion function, pass shell as argument ("bash" or "zsh")
   -f, --format string                 generators rows in f format. Available formats: csv|tab|sql
   -g, --generator string              show help for a specific generator
   -G, --generators                    lists available generators

--- a/integration/golden/unknown-format.golden
+++ b/integration/golden/unknown-format.golden
@@ -2,6 +2,7 @@ unknown format: sqll
 
 Usage: fakedata [option ...] field...
 
+  -C, --completion string             print bash/zsh completion function, pass shell as argument ("bash" or "zsh")
   -f, --format string                 generators rows in f format. Available formats: csv|tab|sql
   -g, --generator string              show help for a specific generator
   -G, --generators                    lists available generators

--- a/integration/golden/unknown-generators.golden
+++ b/integration/golden/unknown-generators.golden
@@ -2,6 +2,7 @@ unknown generator: madeupgenerator
 
 Usage: fakedata [option ...] field...
 
+  -C, --completion string             print bash/zsh completion function, pass shell as argument ("bash" or "zsh")
   -f, --format string                 generators rows in f format. Available formats: csv|tab|sql
   -g, --generator string              show help for a specific generator
   -G, --generators                    lists available generators

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ func findTemplate(path string) string {
 
 func main() {
 	var (
+		completionFlag  string
 		generatorsFlag  = flag.BoolP("generators", "G", false, "lists available generators")
 		generatorFlag   = flag.StringP("generator", "g", "", "show help for a specific generator")
 		constraintsFlag = flag.BoolP("generators-with-constraints", "c", false, "lists available generators with constraints")
@@ -91,11 +92,22 @@ func main() {
 		tableFlag       = flag.StringP("table", "t", "TABLE", "table name of the sql format")
 		templateFlag    = flag.StringP("template", "T", "", "Use template as input")
 	)
+	flag.StringVarP(&completionFlag, "completion", "C", "", "print bash/zsh completion function, pass shell as argument (\"bash\" or \"zsh\")")
+
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stdout, "Usage: fakedata [option ...] field...\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if completionFlag != "" {
+		completion, err := fakedata.PrintShellCompletionFunction(completionFlag)
+		if err != nil {
+			fmt.Println(err)
+		}
+		fmt.Printf("%s\n", completion)
+		os.Exit(0)
+	}
 
 	if *versionFlag {
 		fmt.Println(version)

--- a/main.go
+++ b/main.go
@@ -82,7 +82,6 @@ func findTemplate(path string) string {
 
 func main() {
 	var (
-		completionFlag  string
 		generatorsFlag  = flag.BoolP("generators", "G", false, "lists available generators")
 		generatorFlag   = flag.StringP("generator", "g", "", "show help for a specific generator")
 		constraintsFlag = flag.BoolP("generators-with-constraints", "c", false, "lists available generators with constraints")
@@ -91,8 +90,8 @@ func main() {
 		versionFlag     = flag.BoolP("version", "v", false, "shows version information")
 		tableFlag       = flag.StringP("table", "t", "TABLE", "table name of the sql format")
 		templateFlag    = flag.StringP("template", "T", "", "Use template as input")
+		completionFlag  = flag.StringP("completion", "C", "", "print bash/zsh completion function, pass shell as argument (\"bash\" or \"zsh\")")
 	)
-	flag.StringVarP(&completionFlag, "completion", "C", "", "print bash/zsh completion function, pass shell as argument (\"bash\" or \"zsh\")")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stdout, "Usage: fakedata [option ...] field...\n\n")
@@ -100,8 +99,8 @@ func main() {
 	}
 	flag.Parse()
 
-	if completionFlag != "" {
-		completion, err := fakedata.PrintShellCompletionFunction(completionFlag)
+	if *completionFlag != "" {
+		completion, err := fakedata.PrintShellCompletionFunction(*completionFlag)
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/pkg/fakedata/completion.go
+++ b/pkg/fakedata/completion.go
@@ -1,0 +1,70 @@
+package fakedata
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/kevingimbel/fakedata/pkg/fakedata"
+	"github.com/spf13/pflag"
+)
+
+const (
+	bashTemplate = `
+_fakedata()
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="%s"
+
+    if [[ ${cur} == * ]] ; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+}
+complete -F _fakedata fakedata`
+
+	zshTemplate = `
+_fakedata () {
+    local -a commands
+    IFS=$'\n'
+    commands=(%s)
+    _describe 'arguments' commands
+}
+compdef _fakedata fakedata`
+)
+
+var allCliArgs bytes.Buffer
+
+func findCompletionTemplate(sh string) (string, error) {
+	switch sh {
+	case "bash":
+		return bashTemplate, nil
+
+	case "zsh":
+		return zshTemplate, nil
+	}
+	return "", errors.New("Shell could not be found.\nPlease set the $SHELL environment variable and make sure you use one of the supported shells.")
+}
+
+func PrintShellCompletionFunction(sh string) (completion string, err error) {
+	var gens bytes.Buffer
+	for _, gen := range fakedata.Generators() {
+		gens.WriteString(gen.Name + " ")
+	}
+
+	pflag.VisitAll(func(f *pflag.Flag) {
+		allCliArgs.WriteString(fmt.Sprintf("-%s --%s ", f.Shorthand, f.Name))
+	})
+
+	t, err := findCompletionTemplate(sh)
+
+	if err != nil {
+		return "", err
+	}
+
+	cmdList := gens.String() + " " + allCliArgs.String()
+	return fmt.Sprintf(t, cmdList), nil
+}

--- a/pkg/fakedata/completion.go
+++ b/pkg/fakedata/completion.go
@@ -43,7 +43,7 @@ func findCompletionTemplate(sh string) (string, error) {
 	case "zsh":
 		return zshTemplate, nil
 	}
-	return "", errors.New("Shell could not be found.\nPlease set the $SHELL environment variable and make sure you use one of the supported shells.")
+	return "", errors.New("Shell is not supported. See https://github.com/lucapette/fakedata#completion")
 }
 
 func PrintShellCompletionFunction(sh string) (completion string, err error) {

--- a/pkg/fakedata/completion.go
+++ b/pkg/fakedata/completion.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kevingimbel/fakedata/pkg/fakedata"
 	"github.com/spf13/pflag"
 )
 
@@ -36,8 +35,6 @@ _fakedata () {
 compdef _fakedata fakedata`
 )
 
-var allCliArgs bytes.Buffer
-
 func findCompletionTemplate(sh string) (string, error) {
 	switch sh {
 	case "bash":
@@ -50,13 +47,15 @@ func findCompletionTemplate(sh string) (string, error) {
 }
 
 func PrintShellCompletionFunction(sh string) (completion string, err error) {
-	var gens bytes.Buffer
-	for _, gen := range fakedata.Generators() {
-		gens.WriteString(gen.Name + " ")
+	gens := &bytes.Buffer{}
+	allCliArgs := &bytes.Buffer{}
+
+	for _, gen := range NewGenerators() {
+		fmt.Fprintf(gens, gen.Name+" ")
 	}
 
 	pflag.VisitAll(func(f *pflag.Flag) {
-		allCliArgs.WriteString(fmt.Sprintf("-%s --%s ", f.Shorthand, f.Name))
+		fmt.Fprintf(allCliArgs, "-%s --%s ", f.Shorthand, f.Name)
 	})
 
 	t, err := findCompletionTemplate(sh)

--- a/pkg/fakedata/completion_test.go
+++ b/pkg/fakedata/completion_test.go
@@ -1,0 +1,28 @@
+package fakedata
+
+import (
+	"testing"
+)
+
+func TestPrintShellCompletionFunction(t *testing.T) {
+	var tests = []struct {
+		Name    string
+		Input   string
+		WantErr bool
+	}{
+		{"zsh shell", "zsh", false},
+		{"bash shell", "bash", false},
+		{"fish shell", "fish", true},
+		{"bsh shell (spelling mistake)", "bsh", true},
+		{"empty", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			_, err := PrintShellCompletionFunction(tt.Input)
+			if err != nil && !tt.WantErr {
+				t.Errorf("Shell Completion error. Got %v but want %v", err, tt.WantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a pull request for feature #25 

## Synopsis 

bash/zsh completion gives the user a way to `tab` through available generators and options/arguments when using fakedata.

A user can type `fakedata i[TAB]` to get a list of available arguments and generators.
```
$ fakedata i
 -- arguments --
int   ipv4  ipv6
```

### How to enable

At the moment the completion functions needs to be added to the `.zshrc` or `.bashrc` file. Using `eval()` does not work yet.
```
# zsh
$ fakedata --completion zsh >> ~/.zshrc

#bash
$ fakedata --completion zsh >> ~/.bashrc
```

Here's an asciinema showing the current implementation: https://asciinema.org/a/lpxxldZqyTnbUoeR3aKnO2kHt

This is a _work in progress_ as I'd like to get the `eval $()`-thing to work. It's easier to use/maintain then adding the function to `bashrc`/`zshrc`. 

## Todo

- Documentation
- `eval $()`-functionality 