### PR TITLE
Support loops of varying length

### DIFF
--- a/pkg/fakedata/template.go
+++ b/pkg/fakedata/template.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
+	"math/rand"
 )
 
 type templateFactory struct {
@@ -17,7 +18,17 @@ func newTemplateFactory() *templateFactory {
 
 func (tf templateFactory) getFunctions() template.FuncMap {
 	funcMap := template.FuncMap{
-		"Loop": func(i int) []int { return make([]int, i) },
+		"Loop": func(min int, max int) []int {
+			var size int;
+
+			if max == 0 {
+				size = min;
+			} else {
+				size = rand.Intn(max - min) + min;
+			}
+
+			return make([]int, size)
+		},
 		"Odd":  func(i int) bool { return i%2 != 0 },
 		"Even": func(i int) bool { return i%2 == 0 },
 	}

--- a/pkg/fakedata/template.go
+++ b/pkg/fakedata/template.go
@@ -18,12 +18,14 @@ func newTemplateFactory() *templateFactory {
 
 func (tf templateFactory) getFunctions() template.FuncMap {
 	funcMap := template.FuncMap{
-		"Loop": func(min int, max int) []int {
+		"Loop": func(minmax ...int) []int {
 			var size int;
 
-			if max == 0 {
-				size = min;
+			if len(minmax) == 1 {
+				size = minmax[0];
 			} else {
+				min := minmax[0];
+				max := minmax[1];
 				size = rand.Intn(max - min) + min;
 			}
 

--- a/pkg/fakedata/template.go
+++ b/pkg/fakedata/template.go
@@ -2,10 +2,10 @@ package fakedata
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"text/template"
-	"math/rand"
 )
 
 type templateFactory struct {
@@ -19,14 +19,14 @@ func newTemplateFactory() *templateFactory {
 func (tf templateFactory) getFunctions() template.FuncMap {
 	funcMap := template.FuncMap{
 		"Loop": func(minmax ...int) []int {
-			var size int;
+			var size int
 
 			if len(minmax) == 1 {
-				size = minmax[0];
+				size = minmax[0]
 			} else {
-				min := minmax[0];
-				max := minmax[1];
-				size = rand.Intn(max - min) + min;
+				min := minmax[0]
+				max := minmax[1]
+				size = rand.Intn(max-min) + min
 			}
 
 			return make([]int, size)


### PR DESCRIPTION
Fixes #56

This code does not yet have tests. It does not account for the following corner cases:

* a zero is passed as any of `range Loop` arguments,
* `max` is less than `min`, e.g. `range Loop 10 5` – this case is not handled,
* a negative number is passed as any of `range Loop` arguments (I think it makes sense to use `uint` everywhere in `range Loop`),
* a non-digit is passed as any of `range Loop` arguments,
* three or more arguments are passed to `range Loop` (in fact, in case more than 2 args are passed – redundant args will be ignored),
* an integer more than `MaxInt` is passed as any of `range Loop` arguments,
* what will be if min = max?