### PR TITLE
Fixes #63

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,17 @@ func main() {
 		if generator := generators.FindByName(*generatorFlag); generator != nil {
 			fmt.Printf("Description: %s\n\nExample:\n\n", generator.Desc)
 			for i := 0; i < 5; i++ {
-				fmt.Println(generator.Func())
+				fn := generator.Func
+				if generator.IsCustom() {
+					custom, err := generator.CustomFunc("")
+					if err != nil {
+						fmt.Printf("could not generate example: %v", err)
+						os.Exit(1)
+					}
+
+					fn = custom
+				}
+				fmt.Println(fn())
 			}
 		}
 		os.Exit(0)
@@ -162,7 +172,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("%v\n\n", err)
 		flag.Usage()
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	for i := 0; i < *limitFlag; i++ {


### PR DESCRIPTION
This bug was introduced with CustomFunc. Some generators accept input (we call the input "constraints") and, as of now, there's no way to run a custom generator with default input (the concept doesn't exist yet, defaults are hard coded inside the generators function).

I added a couple of simple integration tests to make sure we don't break it moving forward (to be honest, it's a very simple test but it gives us enough confidence things are glued together correctly for the `-g` flag).

The fact we can't run custom generators using the same function is a known desing limitation of fakedata. And this bug fix is a good reminder we should improve its design in this area.

@kevingimbel I did some minor cosmetic changes to the tests too. If you're fine with what I've done, feel free to merge it so I can cut a bug fix release :) 