### PR TITLE
Fixes #62

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go: 
-   - 1.8
+   - 1.9
    - master
 install:
   - make setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,24 @@
 # Contributing
 
-We love every form of contribution. By participating to this project, you
-agree to abide to the `fakedata` [code of conduct](/CODE_OF_CONDUCT.md).
+We love every form of contribution. By participating to this project, you agree
+to abide to the `fakedata` [code of conduct](/CODE_OF_CONDUCT.md).
 
 ## Setup your machine
 
-Our [Makefile](/Makefile) is the entry point for most of the activities you
-will run into as a contributor. To get a basic understanding of what you can
-do with it, you can run:
+Our [Makefile](/Makefile) is the entry point for most of the activities you will
+run into as a contributor. To get a basic understanding of what you can do with
+it, you can run:
 
 ```sh
 $ make help
 ```
 
 Which shows all the documented targets. `fakedata` is written in
-[Go](https://golang.org/). Here is a list of prerequisites to
-build and test the code:
+[Go](https://golang.org/). Here is a list of prerequisites to build and test the
+code:
 
 * `make`
-* [Go 1.8+](http://golang.org/doc/install)
+* [Go 1.9+](http://golang.org/doc/install)
 
 Clone `fakedata` from source:
 
@@ -39,8 +39,8 @@ A good way of making sure everything is all right is running the test suite:
 $ make test
 ```
 
-Please open an [issue](https://github.com/lucapette/fakedata/issues/new)
-if you run into any problem.
+Please open an [issue](https://github.com/lucapette/fakedata/issues/new) if you
+run into any problem.
 
 ## Building and running fakedata
 
@@ -108,9 +108,10 @@ When you are satisfied with the changes, we suggest running:
 $ make ci
 ```
 
-This command runs all the linters and runs all the tests.
+This command runs the linters and the tests the same way we run them in our CI
+system.
 
 ## Submit a pull request
 
-Push your branch to your `fakedata` fork and open a pull request against
-the master branch.
+Push your branch to your `fakedata` fork and open a pull request against the
+master branch.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCE_FILES?=$$(go list ./... | grep -v '/fakedata/vendor/')
+SOURCE_FILES?=$$(go list ./...)
 TEST_PATTERN?=.
 TEST_OPTIONS?=
 
@@ -14,6 +14,7 @@ lint: ## Run all the linters
 	--enable=vet \
 	--enable=gofmt \
 	--enable=errcheck \
+	--enable=golint \
 	./...
 
 ci: lint test ## Run all the tests and code checks

--- a/README.md
+++ b/README.md
@@ -379,7 +379,8 @@ you get started.
 
 You are expected to follow our [code of conduct](/CODE_OF_CONDUCT.md) when
 interacting with the project via issues, pull requests or in any other form.
-Many thanks to the awesome [contributor covenant](http://contributor-covenant.org/) initiative!
+Many thanks to the awesome [contributor
+covenant](http://contributor-covenant.org/) initiative!
 
 # License
 

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -45,6 +45,7 @@ func newGoldenFile(t *testing.T, name string) *testFile {
 }
 
 func (tf *testFile) path() string {
+	tf.t.Helper()
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
 		tf.t.Fatal("problems recovering caller information")
@@ -54,6 +55,7 @@ func (tf *testFile) path() string {
 }
 
 func (tf *testFile) write(content string) {
+	tf.t.Helper()
 	err := ioutil.WriteFile(tf.path(), []byte(content), 0644)
 	if err != nil {
 		tf.t.Fatalf("could not write %s: %v", tf.name, err)
@@ -61,6 +63,7 @@ func (tf *testFile) write(content string) {
 }
 
 func (tf *testFile) asFile() *os.File {
+	tf.t.Helper()
 	file, err := os.Open(tf.path())
 	if err != nil {
 		tf.t.Fatalf("could not open %s: %v", tf.name, err)
@@ -69,6 +72,8 @@ func (tf *testFile) asFile() *os.File {
 }
 
 func (tf *testFile) load() string {
+	tf.t.Helper()
+
 	content, err := ioutil.ReadFile(tf.path())
 	if err != nil {
 		tf.t.Fatalf("could not read file %s: %v", tf.name, err)

--- a/pkg/fakedata/completion.go
+++ b/pkg/fakedata/completion.go
@@ -36,18 +36,21 @@ const fishTemplate = `
 complete -c fakedata -a '%s'
 `
 
-func getTemplate(sh string) (string, error) {
-	switch sh {
+func getTemplate(shell string) (string, error) {
+	switch shell {
 	case "bash":
 		return bashTemplate, nil
 	case "zsh":
 		return zshTemplate, nil
 	case "fish":
 		return fishTemplate, nil
+	default:
+		return "", fmt.Errorf("shell %s not supported. See https://github.com/lucapette/fakedata#completion", shell)
 	}
-	return "", fmt.Errorf("shell %s not supported. See https://github.com/lucapette/fakedata#completion", sh)
 }
 
+// GetCompletionFunc returns a string representing a completion function for the
+// given shell. It returns an error for unsupported shell.
 func GetCompletionFunc(shell string) (string, error) {
 	t, err := getTemplate(shell)
 	if err != nil {


### PR DESCRIPTION
Go 1.9 introduces two features I was waiting for a while

- Better support for test helpers
- go list ./... doesn't list vendor go files (which is a much saner default)

This commit makes use of both features and updates documentation.

Since I was at it, I added golint to the linting process so we don't forget to document exported functions anymore (which we did in the past often enough).

@kevingimbel I wouldn't mind a quick look here :)