### PR TITLE
Makefile: Fix broken integration target on macOS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build-debug-image:
 	docker build -t fakedata .
 
 build-with-cover: ## Build a cover version of fakedata
-	@rm .coverdata -fr
+	@rm -fr .coverdata
 	@mkdir .coverdata
 	@go build -cover -o ./fakedata-with-cover
 


### PR DESCRIPTION
The integration tests were broken on macOS:

	$ make integration
	rm: .coverdata: No such file or directory
	rm: -fr: No such file or directory
	make: *** [build-with-cover] Error 1

`rm` on macOS requires that the options must be given before the argument(s).